### PR TITLE
Внесены изменения, command и query переименована в actionDod. UseCase…

### DIFF
--- a/src/app/module/module.ts
+++ b/src/app/module/module.ts
@@ -27,11 +27,11 @@ export abstract class Module<M_TYPE extends ModuleType> {
     this.useCases.forEach((useCase) => useCase.init(moduleResolver));
   }
 
-  getUseCaseByActionName(actionDodName: string): UseCase<GeneralARDParams> {
-    const useCase = this.useCases.find((uc) => uc.getName() === actionDodName);
+  getUseCaseByName(name: string): UseCase<GeneralARDParams> {
+    const useCase = this.useCases.find((uc) => uc.getName() === name);
     if (useCase === undefined) {
       this.logger.error(
-        `not finded in module "${this.moduleName}" usecase by name "${actionDodName}"`,
+        `not finded in module "${this.moduleName}" usecase by name "${name}"`,
         { useCaseNames: this.useCases.map((uc) => uc.getName()) },
       );
     }

--- a/src/app/module/module.ts
+++ b/src/app/module/module.ts
@@ -27,11 +27,14 @@ export abstract class Module<M_TYPE extends ModuleType> {
     this.useCases.forEach((useCase) => useCase.init(moduleResolver));
   }
 
-  getUseCase<T extends typeof UseCase>(Cls: T): InstanceType<T> {
-    const finded = this.useCases.find((useCase) => useCase.constructor.name === Cls.name);
-    if (finded === undefined) {
-      this.logger.error(`not finded in module "${this.moduleName}" usecase by name ${Cls.name}`, this.useCases);
+  getUseCaseByActionName(actionDodName: string): UseCase<GeneralARDParams> {
+    const useCase = this.useCases.find((uc) => uc.getName() === actionDodName);
+    if (useCase === undefined) {
+      this.logger.error(
+        `not finded in module "${this.moduleName}" usecase by name "${actionDodName}"`,
+        { useCaseNames: this.useCases.map((uc) => uc.getName()) },
+      );
     }
-    return finded as InstanceType<T>;
+    return useCase;
   }
 }

--- a/src/app/use-case/command-use-case.ts
+++ b/src/app/use-case/command-use-case.ts
@@ -1,45 +1,6 @@
-import {
-  GeneralCommandUcParams, GetUcOptions,
-} from './types';
-import { CommandValidatorMap } from '../../domain/validator/field-validator/types';
-import { failure } from '../../common/result/failure';
-import { Result } from '../../common/result/types';
-import { Locale } from '../../domain/locale';
+import { GeneralCommandUcParams } from './types';
 import { QueryUseCase } from './query-use-case';
-import { PermissionDeniedError, ValidationError } from './error-types';
 
 export abstract class CommandUseCase<
   UC_PARAMS extends GeneralCommandUcParams,
-> extends QueryUseCase<UC_PARAMS> {
-  protected abstract validatorMap: CommandValidatorMap<UC_PARAMS['inputOptions']['command']>;
-
-  /**
-   * Выполнить проверку разрешений, которую можно выполнить до
-   * выполнения доменной логики и её проверок.
-   * */
-  protected async runInitialChecks(
-    options: GetUcOptions<UC_PARAMS>,
-  ): Promise<Result<ValidationError | PermissionDeniedError<Locale>, undefined>> {
-    const checkCallerResult = this.checkCallerPermission(options.caller);
-    if (checkCallerResult.isFailure()) return checkCallerResult;
-
-    return this.checkValidations(options);
-  }
-
-  protected checkValidations(
-    input: GetUcOptions<UC_PARAMS>,
-  ): Result<ValidationError, undefined> {
-    const result = this.validatorMap.validate(input.command.attrs);
-
-    if (result.isFailure()) {
-      const err: ValidationError = {
-        name: 'validation-error',
-        domainType: 'error',
-        errorType: 'app-error',
-        errors: result.value,
-      };
-      return failure(err);
-    }
-    return result;
-  }
-}
+> extends QueryUseCase<UC_PARAMS> {}

--- a/src/app/use-case/query-use-case.ts
+++ b/src/app/use-case/query-use-case.ts
@@ -7,7 +7,7 @@ import { Locale } from '../../domain/locale';
 import { Caller, CallerType } from '../caller';
 import {
   GeneralQueryUcParams, GetUcOptions, GetARParamsFromUcParams, GetUcResult,
-  GetRequestDodBody, ActionDodValidator, GetActionDodName,
+  GetActionDodBody, ActionDodValidator, GetActionDodName,
 } from './types';
 import { UseCase } from './use-case';
 import { InternalError, PermissionDeniedError, ValidationError } from './error-types';
@@ -68,7 +68,7 @@ export abstract class QueryUseCase<UC_PARAMS extends GeneralQueryUcParams>
   }
 
   protected checkValidations(
-    requestDod: GetRequestDodBody<UC_PARAMS>,
+    requestDod: GetActionDodBody<UC_PARAMS>,
   ): Result<ValidationError, undefined> {
     const result = this.validatorMap.validate(requestDod);
 

--- a/src/app/use-case/query-use-case.ts
+++ b/src/app/use-case/query-use-case.ts
@@ -68,9 +68,9 @@ export abstract class QueryUseCase<UC_PARAMS extends GeneralQueryUcParams>
   }
 
   protected checkValidations(
-    requestDod: GetActionDodBody<UC_PARAMS>,
+    actionDod: GetActionDodBody<UC_PARAMS>,
   ): Result<ValidationError, undefined> {
-    const result = this.validatorMap.validate(requestDod);
+    const result = this.validatorMap.validate(actionDod);
 
     if (result.isFailure()) {
       const err: ValidationError = {

--- a/src/app/use-case/query-use-case.ts
+++ b/src/app/use-case/query-use-case.ts
@@ -6,17 +6,22 @@ import { dodUtility } from '../../common/utils/domain-object/dod-utility';
 import { Locale } from '../../domain/locale';
 import { Caller, CallerType } from '../caller';
 import {
-  GeneralQueryUcParams, GetUcOptions, GetUcParamsARParams, GetUcResult,
+  GeneralQueryUcParams, GetUcOptions, GetARParamsFromUcParams, GetUcResult,
+  GetRequestDodBody, ActionDodValidator, GetActionDodName,
 } from './types';
 import { UseCase } from './use-case';
-import { InternalError, PermissionDeniedError } from './error-types';
+import { InternalError, PermissionDeniedError, ValidationError } from './error-types';
 
 export abstract class QueryUseCase<UC_PARAMS extends GeneralQueryUcParams>
-  extends UseCase<GetUcParamsARParams<UC_PARAMS>> {
+  extends UseCase<GetARParamsFromUcParams<UC_PARAMS>> {
+  protected abstract name: GetActionDodName<UC_PARAMS>;
+
   protected abstract supportedCallers: ReadonlyArray<CallerType>;
 
   /** выполнение доменной логики */
   protected abstract runDomain(options: GetUcOptions<UC_PARAMS>): Promise<GetUcResult<UC_PARAMS>>
+
+  protected abstract validatorMap: ActionDodValidator<UC_PARAMS>;
 
   async execute(options: GetUcOptions<UC_PARAMS>): Promise<GetUcResult<UC_PARAMS>> {
     try {
@@ -38,10 +43,16 @@ export abstract class QueryUseCase<UC_PARAMS extends GeneralQueryUcParams>
   }
 
   /**
-   * Выполнить проверку какие либо проверки до выполнения доменной логики.
+   * Выполнить проверку разрешений, которую можно выполнить до
+   * выполнения доменной логики и её проверок.
    * */
-  protected async runInitialChecks(..._args: unknown[]): Promise<Result<unknown, unknown>> {
-    return success(undefined);
+  protected async runInitialChecks(
+    options: GetUcOptions<UC_PARAMS>,
+  ): Promise<Result<ValidationError | PermissionDeniedError<Locale>, undefined>> {
+    const checkCallerResult = this.checkCallerPermission(options.caller);
+    if (checkCallerResult.isFailure()) return checkCallerResult;
+
+    return this.checkValidations(options);
   }
 
   // eslint-disable-next-line max-len
@@ -54,5 +65,22 @@ export abstract class QueryUseCase<UC_PARAMS extends GeneralQueryUcParams>
       { allowedOnlyFor: this.supportedCallers },
     );
     return failure(err);
+  }
+
+  protected checkValidations(
+    requestDod: GetRequestDodBody<UC_PARAMS>,
+  ): Result<ValidationError, undefined> {
+    const result = this.validatorMap.validate(requestDod);
+
+    if (result.isFailure()) {
+      const err: ValidationError = {
+        name: 'validation-error',
+        domainType: 'error',
+        errorType: 'app-error',
+        errors: result.value,
+      };
+      return failure(err);
+    }
+    return result;
   }
 }

--- a/src/app/use-case/types.ts
+++ b/src/app/use-case/types.ts
@@ -32,7 +32,7 @@ export type QueryUseCaseParams<
   AR_PARAMS extends GeneralARDParams,
   INPUT_OPT extends GeneralInputOptions, // что входит в useCase,
   SUCCESS_OUT, // ответ клиенту в случае успеха
-  FAIL_OUT extends GeneralErrorDod, // возвращаемый ответ в случае не успеха
+  FAIL_OUT extends GeneralErrorDod | UseCaseBaseErrors, // возвращаемый ответ в случае не успеха
 > = {
   inputOptions: INPUT_OPT,
   successOut: SUCCESS_OUT,
@@ -40,7 +40,7 @@ export type QueryUseCaseParams<
 }
 
 export type GeneralQueryUcParams = QueryUseCaseParams<
-  GeneralARDParams, GeneralInputOptions, unknown, GeneralErrorDod
+  GeneralARDParams, GeneralInputOptions, unknown, GeneralErrorDod | UseCaseBaseErrors
 >;
 
 export type GeneraQuerylUseCase = QueryUseCase<GeneralQueryUcParams>;
@@ -68,7 +68,7 @@ export type ActionDodValidator<UC_PARAMS extends GeneralQueryUcParams | GeneralC
   DtoFieldValidator<
     GetActionDodName<UC_PARAMS>,
     true, false,
-    GetRequestDodBody<UC_PARAMS>
+    GetActionDodBody<UC_PARAMS>
   >
 
 export type GetUcResult<P extends GeneralQueryUcParams | GeneralCommandUcParams> = Result<
@@ -92,5 +92,5 @@ export type GetARParamsFromUcParams<P extends GeneralQueryUcParams | GeneralComm
 export type GetActionDodName<UC_PARAMS extends GeneralQueryUcParams | GeneralCommandUcParams> =
   UC_PARAMS['inputOptions']['actionDod']['actionName']
 
-export type GetRequestDodBody<UC_PARAMS extends GeneralQueryUcParams | GeneralCommandUcParams> =
+export type GetActionDodBody<UC_PARAMS extends GeneralQueryUcParams | GeneralCommandUcParams> =
   UC_PARAMS['inputOptions']['actionDod']['body']

--- a/src/app/use-case/types.ts
+++ b/src/app/use-case/types.ts
@@ -1,16 +1,18 @@
+/* eslint-disable no-use-before-define */
 import { Result } from '../../common/result/types';
 import { GetArrayType } from '../../common/type-functions';
 import { GeneralARDParams } from '../../domain/domain-object-data/aggregate-data-types';
 import {
-  GeneralCommandDod, GeneralErrorDod, GeneralEventDod,
+  GeneralErrorDod, GeneralEventDod, ActionDod,
 } from '../../domain/domain-object-data/common-types';
+import { DtoFieldValidator } from '../../domain/validator/field-validator/dto-field-validator';
 import { Caller } from '../caller';
 import { ModuleType } from '../module/types';
 import { CommandUseCase } from './command-use-case';
 import { UseCaseBaseErrors } from './error-types';
 import { QueryUseCase } from './query-use-case';
 
-export type AppEventType = 'command-event' | 'read-event' | 'event';
+export type AppEventType = 'command-event' | 'read-module' | 'event';
 
 export type GetAppEventDod<EVENTS extends GeneralEventDod[], M_TYPE extends ModuleType> =
   M_TYPE extends 'command-module'
@@ -19,29 +21,33 @@ export type GetAppEventDod<EVENTS extends GeneralEventDod[], M_TYPE extends Modu
       ? Array<GetArrayType<EVENTS> & { event: 'read-event' }>
       : EVENTS
 
+export type InputOptions<A extends ActionDod> = {
+  actionDod: A,
+  caller: Caller,
+}
+
+export type GeneralInputOptions = InputOptions<ActionDod>;
+
 export type QueryUseCaseParams<
   AR_PARAMS extends GeneralARDParams,
-  INPUT_OPT, // что входит в useCase,
+  INPUT_OPT extends GeneralInputOptions, // что входит в useCase,
   SUCCESS_OUT, // ответ клиенту в случае успеха
-  FAIL_OUT, // возвращаемый ответ в случау не успеха
+  FAIL_OUT extends GeneralErrorDod, // возвращаемый ответ в случае не успеха
 > = {
   inputOptions: INPUT_OPT,
   successOut: SUCCESS_OUT,
   errors: FAIL_OUT,
 }
 
-export type GeneralQueryUcParams = QueryUseCaseParams<GeneralARDParams, unknown, unknown, unknown>;
+export type GeneralQueryUcParams = QueryUseCaseParams<
+  GeneralARDParams, GeneralInputOptions, unknown, GeneralErrorDod
+>;
 
 export type GeneraQuerylUseCase = QueryUseCase<GeneralQueryUcParams>;
 
-export type CommandUCOptions = {
-  command: GeneralCommandDod,
-  caller: Caller,
-}
-
 export type CommandUseCaseParams<
   AR_PARAMS extends GeneralARDParams,
-  INPUT_OPT extends CommandUCOptions, // что входит в useCase,
+  INPUT_OPT extends GeneralInputOptions, // что входит в useCase,
   SUCCESS_OUT, // ответ в случае успеха
   FAIL_OUT extends GeneralErrorDod, // доменные ошибки при выполнении запроса
   EVENTS extends GeneralEventDod[], // публикуемые доменные события
@@ -53,10 +59,17 @@ export type CommandUseCaseParams<
 }
 
 export type GeneralCommandUcParams = CommandUseCaseParams<
-  GeneralARDParams, CommandUCOptions, unknown, GeneralErrorDod, GeneralEventDod[]
+  GeneralARDParams, GeneralInputOptions, unknown, GeneralErrorDod, GeneralEventDod[]
 >;
 
 export type GeneralCommandUseCase = CommandUseCase<GeneralCommandUcParams>;
+
+export type ActionDodValidator<UC_PARAMS extends GeneralQueryUcParams | GeneralCommandUcParams> =
+  DtoFieldValidator<
+    GetActionDodName<UC_PARAMS>,
+    true, false,
+    GetRequestDodBody<UC_PARAMS>
+  >
 
 export type GetUcResult<P extends GeneralQueryUcParams | GeneralCommandUcParams> = Result<
   P['errors'] | UseCaseBaseErrors,
@@ -68,11 +81,16 @@ export type GetUcErrorsResult<P extends GeneralQueryUcParams> =
 
 export type GetUcOptions<P extends GeneralQueryUcParams> = P['inputOptions'];
 
-export type GetUcParamsARParams<UCPARAMS extends GeneralQueryUcParams | GeneralCommandUcParams> =
-  UCPARAMS extends QueryUseCaseParams<infer AR_PARAMS, unknown, unknown, unknown>
-    ? AR_PARAMS
-    : UCPARAMS extends CommandUseCaseParams<
-      infer AR_PARAMS, CommandUCOptions, unknown, GeneralErrorDod, GeneralEventDod[]
-    >
-      ? AR_PARAMS
+export type GetARParamsFromUcParams<P extends GeneralQueryUcParams | GeneralCommandUcParams> =
+  // eslint-disable-next-line max-len
+  P extends CommandUseCaseParams<infer T, GeneralInputOptions, unknown, GeneralErrorDod, GeneralEventDod[]>
+    ? T
+    : P extends QueryUseCaseParams<infer T2, GeneralInputOptions, unknown, GeneralErrorDod>
+      ? T2
       : never
+
+export type GetActionDodName<UC_PARAMS extends GeneralQueryUcParams | GeneralCommandUcParams> =
+  UC_PARAMS['inputOptions']['actionDod']['actionName']
+
+export type GetRequestDodBody<UC_PARAMS extends GeneralQueryUcParams | GeneralCommandUcParams> =
+  UC_PARAMS['inputOptions']['actionDod']['body']

--- a/src/app/use-case/use-case.ts
+++ b/src/app/use-case/use-case.ts
@@ -6,6 +6,8 @@ import { GetARParamsAggregateName } from '../../domain/domain-object-data/type-f
 export abstract class UseCase<ARP extends GeneralARDParams> {
   protected abstract aggregateName: GetARParamsAggregateName<ARP>;
 
+  protected abstract name: string;
+
   protected moduleResolver!: ModuleResolver;
 
   protected logger!: Logger;
@@ -16,4 +18,12 @@ export abstract class UseCase<ARP extends GeneralARDParams> {
   }
 
   abstract execute(...args: unknown[]): Promise<unknown>
+
+  getAggregateName(): string {
+    return this.aggregateName;
+  }
+
+  getName(): string {
+    return this.name;
+  }
 }

--- a/src/domain/domain-object-data/common-types.ts
+++ b/src/domain/domain-object-data/common-types.ts
@@ -54,18 +54,10 @@ export type EventDod<ATTRS extends DomainAttrs, NAME extends string> = {
 
 export type GeneralEventDod = EventDod<DomainAttrs, Name>;
 
-export type UseCaseQueryDod<ATTRS extends DomainAttrs, NAME extends string> = {
-  attrs: ATTRS,
-  name: NAME,
+export type ActionDod = {
+  actionName: string,
+  body: DTO,
 }
-
-export type UseCaseCommandDod<ATTRS extends DomainAttrs, NAME extends string> = {
-  attrs: ATTRS,
-  name: NAME,
-  commandId?: UuidType,
-}
-
-export type GeneralCommandDod = UseCaseCommandDod<DTO, string>;
 
 export type GetDomainAttrs<D extends GeneralARDTransfer> =
   D extends AggregateRootDataTransfer<infer A, infer _> ? A : never;

--- a/src/domain/validator/field-validator/types.ts
+++ b/src/domain/validator/field-validator/types.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-use-before-define */
 import { Result } from '../../../common/result/types';
-import { GeneralCommandDod } from '../../domain-object-data/common-types';
 import { DTO } from '../../dto';
 import { LiteralDataType, RuleError } from '../../validator/rules/types';
 import { DtoFieldValidator } from './dto-field-validator';
@@ -79,6 +78,3 @@ export type ValidatorMap<DTO_TYPE extends DTO> = {
         ? GetValidator<KEY, true, true, NonNullable<ARR_TYPE>>
         : GetValidator<KEY, true, false, NonNullable<DTO_TYPE[KEY]>>
 }
-
-export type CommandValidatorMap<CMD extends GeneralCommandDod> =
-  DtoFieldValidator<CMD['name'], true, false, CMD['attrs']>;

--- a/tests/test-implements/subject/cm-use-case/adding-person/params.ts
+++ b/tests/test-implements/subject/cm-use-case/adding-person/params.ts
@@ -1,16 +1,14 @@
-import { Caller } from '../../../../../src/app/caller';
-import { CommandUseCaseParams, GetUcResult } from '../../../../../src/app/use-case/types';
-import { UseCaseCommandDod } from '../../../../../src/domain/domain-object-data/common-types';
+import { CommandUseCaseParams, GetUcResult, InputOptions } from '../../../../../src/app/use-case/types';
 import { AllowedOnlyEmployeerError, AllowedOnlyStaffManagersError } from '../../domain-data/company/role-errors';
 import { AddingPersonDomainCommand, PersonAddedEvent, PersonAlreadyExistsError } from '../../domain-data/person/add-person.params';
 import { PersonParams } from '../../domain-data/person/params';
 
-export type AddingPersonUCCommand = UseCaseCommandDod<AddingPersonDomainCommand, 'AddPersonCommand'>;
-
-export type AddingPersonInputOptions = {
-  command: AddingPersonUCCommand,
-  caller: Caller,
+export type AddPersonActionDod = {
+  actionName: 'addPerson',
+  body: AddingPersonDomainCommand
 }
+
+export type AddingPersonInputOptions = InputOptions<AddPersonActionDod>
 
 export type AddingPersonUCParams = CommandUseCaseParams<
   PersonParams,

--- a/tests/test-implements/subject/cm-use-case/adding-person/use-case.ts
+++ b/tests/test-implements/subject/cm-use-case/adding-person/use-case.ts
@@ -1,18 +1,18 @@
 import { CommandUseCase } from '../../../../../src/app/use-case/command-use-case';
 import { GetUcOptions, GetUcResult } from '../../../../../src/app/use-case/types';
 import { AddingPersonUCParams } from './params';
-import { addPersonVMap } from './v-map';
+import { addPersonValidator } from './v-map';
 
 export class AddingPersonUC extends CommandUseCase<AddingPersonUCParams> {
   protected supportedCallers = ['DomainUser'] as const;
 
-  protected validatorMap = addPersonVMap;
+  protected validatorMap = addPersonValidator;
 
   actionType = 'class' as const;
 
   aggregateName = 'PersonAR' as const;
 
-  actionName = 'addPerson' as const;
+  name = 'addPerson' as const;
 
   protected runDomain(
     options: GetUcOptions<AddingPersonUCParams>,

--- a/tests/test-implements/subject/cm-use-case/adding-person/v-map.ts
+++ b/tests/test-implements/subject/cm-use-case/adding-person/v-map.ts
@@ -1,9 +1,10 @@
 /* eslint-disable function-paren-newline */
+import { ActionDodValidator } from '../../../../../src/app/use-case/types';
 import { DtoFieldValidator } from '../../../../../src/domain/validator/field-validator/dto-field-validator';
-import { CommandValidatorMap, ValidatorMap } from '../../../../../src/domain/validator/field-validator/types';
+import { ValidatorMap } from '../../../../../src/domain/validator/field-validator/types';
 import { AddingPersonDomainCommand } from '../../domain-data/person/add-person.params';
 import { personAttrsVMap } from '../../domain-data/person/v-map';
-import { AddingPersonUCCommand } from './params';
+import { AddingPersonUCParams } from './params';
 
 export const addPersonAttrsVMap: ValidatorMap<AddingPersonDomainCommand> = {
   govPersonId: personAttrsVMap.govPersonId,
@@ -12,6 +13,6 @@ export const addPersonAttrsVMap: ValidatorMap<AddingPersonDomainCommand> = {
   patronomic: personAttrsVMap.patronomic,
 };
 
-export const addPersonVMap: CommandValidatorMap<AddingPersonUCCommand> = new DtoFieldValidator(
-  'AddPersonCommand', true, { isArray: false }, 'dto', addPersonAttrsVMap,
+export const addPersonValidator: ActionDodValidator<AddingPersonUCParams> = new DtoFieldValidator(
+  'addPerson', true, { isArray: false }, 'dto', addPersonAttrsVMap,
 );

--- a/tests/test-implements/subject/domain-object/person/factory.ts
+++ b/tests/test-implements/subject/domain-object/person/factory.ts
@@ -2,15 +2,15 @@ import { Caller } from '../../../../../src/app/caller';
 import { dodUtility } from '../../../../../src/common/utils/domain-object/dod-utility';
 import { uuidUtility } from '../../../../../src/common/utils/uuid/uuid-utility';
 import { AggregateFactory } from '../../../../../src/domain/domain-object/aggregate-factory';
-import { AddingPersonUCCommand } from '../../cm-use-case/adding-person/params';
+import { AddPersonActionDod } from '../../cm-use-case/adding-person/params';
 import { PersonAddedEvent } from '../../domain-data/person/add-person.params';
 import { PersonAttrs, PersonParams } from '../../domain-data/person/params';
 import { PersonAR } from './a-root';
 
 export class PersonFactory extends AggregateFactory<PersonParams> {
-  create(caller: Caller, command: AddingPersonUCCommand): PersonAR {
+  create(caller: Caller, actionDod: AddPersonActionDod): PersonAR {
     const personAttrs: PersonAttrs = {
-      ...command.attrs,
+      ...actionDod.body,
       id: uuidUtility.getNewUUID(),
       contacts: { phones: [] },
     };


### PR DESCRIPTION
… теперь имеет name, по нему его можно получить в Module.

1. CommandDod, QueryDod удалены, вместо них теперь ActionDod
2. Теперь Controller будет получать экз. UseCase по ActionDod.name
3. Поэтому теперь будет только один контроллер для одного модуля, который принимает все запросы
4. Запросы должны быть post, потому что вся полезная нагрузка должна идти в json